### PR TITLE
RequestSpecRaw to RequestSpec

### DIFF
--- a/packages/quickjs-types/package.json
+++ b/packages/quickjs-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caido/quickjs-types",
-  "version": "0.16.1",
+  "version": "0.17.1",
   "description": "Typing for the QuickJS Engine",
   "author": "Caido Labs Inc. <dev@caido.io>",
   "license": "MIT",

--- a/packages/quickjs-types/src/caido/requests.d.ts
+++ b/packages/quickjs-types/src/caido/requests.d.ts
@@ -18,7 +18,7 @@ declare module "caido:utils" {
      *
      * @throws {SyntaxError} If the body is not valid JSON.
      */
-    toJson(): any;
+    toJson(): unknown;
     /**
      * Get the raw body as an array of bytes.
      */
@@ -183,6 +183,12 @@ declare module "caido:utils" {
      * ```
      */
     static parse(bytes: Bytes): RequestSpec;
+    /**
+     * Parses the raw bytes of a {@link RequestSpecRaw} into a {@link RequestSpec}.
+     *
+     * @throws {Error} If the bytes are not a valid HTTP request.
+     */
+    static parse(raw: RequestSpecRaw): RequestSpec;
     /**
      * Get the host of the request.
      */
@@ -387,6 +393,13 @@ declare module "caido:utils" {
      * Set the raw {@link Bytes} of the request.
      */
     setRaw(raw: Bytes): void;
+    /**
+     * This methods converts the {@link RequestSpecRaw} to a {@link RequestSpec}.
+     * 
+     * @throws {Error} If the bytes are not a valid HTTP request.
+     * @see {@link RequestSpec.parse}
+     */
+    getSpec(): RequestSpec;
   }
 
   /**


### PR DESCRIPTION
Added `RequestSpecRaw.getSpec` and a `RequestSpec.parse` to facilitate transfers between the two objects.

Methods added in https://github.com/caido/caido/issues/1362.