### PR TITLE
🐛 Fix export type

### DIFF
--- a/packages/sdk-frontend/src/index.d.ts
+++ b/packages/sdk-frontend/src/index.d.ts
@@ -1,2 +1,2 @@
 export type { API as Caido } from "./types";
-export type * from "./types";
+export * from "./types";


### PR DESCRIPTION
Update the re-exports types root from 
`export type * from "./types";`
to 
`export * from "./types"; `

causing no runtime values.