### PR TITLE
Implement DNSRewriteSDK.create() method for DNS rewrite creation

### DIFF
--- a/packages/sdk-client/src/client.ts
+++ b/packages/sdk-client/src/client.ts
@@ -5,6 +5,7 @@ import { ConsoleLogger } from "@/logger.js";
 import type { ClientOptions } from "@/options.js";
 import { RestClient } from "@/rest/index.js";
 import {
+  DNSRewriteSDK,
   EnvironmentSDK,
   FilterSDK,
   FindingSDK,
@@ -43,6 +44,7 @@ import { sleep } from "@/utils/misc.js";
  * - `instance` - Higher-level instance SDK
  * - `request` - Higher-level request SDK
  * - `workflow` - Higher-level workflow SDK
+ * - `dnsRewrite` - Higher-level DNS rewrite SDK
  *
  * @example
  * ```typescript
@@ -102,6 +104,9 @@ export class Client {
   /** Higher-level replay SDK. */
   readonly replay: ReplaySDK;
 
+  /** Higher-level DNS rewrite SDK. */
+  readonly dnsRewrite: DNSRewriteSDK;
+
   private readonly auth: AuthManager;
 
   constructor(options: ClientOptions) {
@@ -136,6 +141,7 @@ export class Client {
     this.workflow = new WorkflowSDK(this.graphql);
     this.task = new TaskSDK(this.graphql);
     this.replay = new ReplaySDK(this.graphql);
+    this.dnsRewrite = new DNSRewriteSDK(this.graphql);
   }
 
   /**

--- a/packages/sdk-client/src/convert/dnsRewrite.ts
+++ b/packages/sdk-client/src/convert/dnsRewrite.ts
@@ -1,0 +1,34 @@
+import type { DnsRewriteFullFragment } from "@/graphql/index.js";
+import type { DNSResolver, DNSRewrite } from "@/types/index.js";
+
+export const mapToDnsRewrite = (node: DnsRewriteFullFragment): DNSRewrite => {
+  return {
+    id: node.id,
+    allowlist: node.allowlist,
+    denylist: node.denylist,
+    enabled: node.enabled,
+    rank: parseInt(node.rank, 10),
+    resolution: mapToDNSResolver(node.resolution),
+  };
+};
+
+const mapToDNSResolver = (
+  resolver: DnsRewriteFullFragment["resolution"],
+): DNSResolver => {
+  if (resolver.__typename === "DnsIpResolver") {
+    return {
+      type: "ip",
+      ip: resolver.ip,
+    };
+  }
+
+  if (resolver.__typename === "DnsUpstreamResolver") {
+    return {
+      type: "upstream",
+      id: resolver.id,
+    };
+  }
+
+  const _exhaustive: never = resolver;
+  throw new Error(`Unknown DNS resolver type: ${_exhaustive}`);
+};

--- a/packages/sdk-client/src/graphql/__generated__/dnsRewrite.ts
+++ b/packages/sdk-client/src/graphql/__generated__/dnsRewrite.ts
@@ -1,0 +1,321 @@
+import type * as Types from "./types.js";
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type DnsRewriteFullFragment = {
+  id: string;
+  allowlist: Array<string>;
+  denylist: Array<string>;
+  enabled: boolean;
+  rank: string;
+  resolution:
+    | { __typename: "DnsIpResolver"; ip: string }
+    | { __typename: "DnsUpstreamResolver"; id: string };
+};
+
+export type CreateDnsRewriteMutationVariables = Types.Exact<{
+  input: Types.CreateDnsRewriteInput;
+}>;
+
+export type CreateDnsRewriteMutation = {
+  createDnsRewrite: {
+    error?:
+      | { __typename: "OtherUserError"; code: string }
+      | { __typename: "UnknownIdUserError"; code: string; id: string }
+      | undefined
+      | null;
+    rewrite?:
+      | {
+          id: string;
+          allowlist: Array<string>;
+          denylist: Array<string>;
+          enabled: boolean;
+          rank: string;
+          resolution:
+            | { __typename: "DnsIpResolver"; ip: string }
+            | { __typename: "DnsUpstreamResolver"; id: string };
+        }
+      | undefined
+      | null;
+  };
+};
+
+export const DnsRewriteFullFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "DnsRewriteFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "DnsRewrite" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "allowlist" } },
+          { kind: "Field", name: { kind: "Name", value: "denylist" } },
+          { kind: "Field", name: { kind: "Name", value: "enabled" } },
+          { kind: "Field", name: { kind: "Name", value: "rank" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "resolution" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "__typename" } },
+                {
+                  kind: "InlineFragment",
+                  typeCondition: {
+                    kind: "NamedType",
+                    name: { kind: "Name", value: "DnsIpResolver" },
+                  },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "ip" } },
+                    ],
+                  },
+                },
+                {
+                  kind: "InlineFragment",
+                  typeCondition: {
+                    kind: "NamedType",
+                    name: { kind: "Name", value: "DnsUpstreamResolver" },
+                  },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DnsRewriteFullFragment, unknown>;
+export const CreateDnsRewriteDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "CreateDnsRewrite" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: {
+            kind: "Variable",
+            name: { kind: "Name", value: "input" },
+          },
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: { kind: "Name", value: "CreateDnsRewriteInput" },
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "createDnsRewrite" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "Variable",
+                  name: { kind: "Name", value: "input" },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "error" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "__typename" },
+                      },
+                      {
+                        kind: "InlineFragment",
+                        typeCondition: {
+                          kind: "NamedType",
+                          name: { kind: "Name", value: "OtherUserError" },
+                        },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: {
+                                kind: "Name",
+                                value: "OtherUserErrorFull",
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "InlineFragment",
+                        typeCondition: {
+                          kind: "NamedType",
+                          name: { kind: "Name", value: "UnknownIdUserError" },
+                        },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: {
+                                kind: "Name",
+                                value: "UnknownIdUserErrorFull",
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "rewrite" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "FragmentSpread",
+                        name: { kind: "Name", value: "DnsRewriteFull" },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "DnsRewriteFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "DnsRewrite" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "allowlist" } },
+          { kind: "Field", name: { kind: "Name", value: "denylist" } },
+          { kind: "Field", name: { kind: "Name", value: "enabled" } },
+          { kind: "Field", name: { kind: "Name", value: "rank" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "resolution" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "__typename" } },
+                {
+                  kind: "InlineFragment",
+                  typeCondition: {
+                    kind: "NamedType",
+                    name: { kind: "Name", value: "DnsIpResolver" },
+                  },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "ip" } },
+                    ],
+                  },
+                },
+                {
+                  kind: "InlineFragment",
+                  typeCondition: {
+                    kind: "NamedType",
+                    name: { kind: "Name", value: "DnsUpstreamResolver" },
+                  },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "OtherUserErrorFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "OtherUserError" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "UserErrorFull" },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "UnknownIdUserErrorFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "UnknownIdUserError" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "FragmentSpread",
+            name: { kind: "Name", value: "UserErrorFull" },
+          },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "UserErrorFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "UserError" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "code" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  CreateDnsRewriteMutation,
+  CreateDnsRewriteMutationVariables
+>;

--- a/packages/sdk-client/src/graphql/documents/dnsRewrite.graphql
+++ b/packages/sdk-client/src/graphql/documents/dnsRewrite.graphql
@@ -1,0 +1,33 @@
+fragment DnsRewriteFull on DnsRewrite {
+  id
+  allowlist
+  denylist
+  enabled
+  rank
+  resolution {
+    __typename
+    ... on DnsIpResolver {
+      ip
+    }
+    ... on DnsUpstreamResolver {
+      id
+    }
+  }
+}
+
+mutation CreateDnsRewrite($input: CreateDnsRewriteInput!) {
+  createDnsRewrite(input: $input) {
+    error {
+      __typename
+      ... on OtherUserError {
+        ...OtherUserErrorFull
+      }
+      ... on UnknownIdUserError {
+        ...UnknownIdUserErrorFull
+      }
+    }
+    rewrite {
+      ...DnsRewriteFull
+    }
+  }
+}

--- a/packages/sdk-client/src/graphql/index.ts
+++ b/packages/sdk-client/src/graphql/index.ts
@@ -16,4 +16,5 @@ export * from "./__generated__/task.js";
 export * from "./__generated__/workflow.js";
 export * from "./__generated__/connectionInfo.js";
 export * from "./__generated__/instanceSettings.js";
+export * from "./__generated__/dnsRewrite.js";
 export * from "./utils.js";

--- a/packages/sdk-client/src/sdks/dnsRewrite.ts
+++ b/packages/sdk-client/src/sdks/dnsRewrite.ts
@@ -1,0 +1,63 @@
+import { mapToDnsRewrite } from "@/convert/dnsRewrite.js";
+import {
+  CreateDnsRewriteDocument,
+  type CreateDnsRewriteMutation,
+  type GraphQLClient,
+} from "@/graphql/index.js";
+import type { CreateDNSRewriteOptions, DNSRewrite } from "@/types/index.js";
+import { handleGraphQLError } from "@/utils/errors.js";
+import { isAbsent, isPresent } from "@/utils/optional.js";
+
+/**
+ * Higher-level SDK for DNS rewrite-related operations.
+ */
+export class DNSRewriteSDK {
+  private readonly graphql: GraphQLClient;
+
+  constructor(graphql: GraphQLClient) {
+    this.graphql = graphql;
+  }
+
+  /**
+   * Create a new DNS rewrite.
+   */
+  async create(options: CreateDNSRewriteOptions): Promise<DNSRewrite> {
+    const resolution = mapFromDNSResolver(options.resolution);
+    const result: CreateDnsRewriteMutation = await this.graphql.mutation(
+      CreateDnsRewriteDocument,
+      {
+        input: {
+          allowlist: options.allowlist,
+          denylist: options.denylist,
+          resolution,
+        },
+      },
+    );
+
+    const payload = result.createDnsRewrite;
+
+    if (isPresent(payload.error)) {
+      handleGraphQLError(payload.error);
+    }
+
+    const rewrite = payload.rewrite;
+    if (isAbsent(rewrite)) {
+      throw new Error("createDnsRewrite returned no rewrite");
+    }
+    return mapToDnsRewrite(rewrite);
+  }
+}
+
+const mapFromDNSResolver = (
+  resolver: CreateDNSRewriteOptions["resolution"],
+) => {
+  if (resolver.type === "ip") {
+    return {
+      ip: { ip: resolver.ip },
+    };
+  }
+
+  return {
+    upstream: { id: resolver.id as string },
+  };
+};

--- a/packages/sdk-client/src/sdks/index.ts
+++ b/packages/sdk-client/src/sdks/index.ts
@@ -28,3 +28,4 @@ export {
   ReplayCollectionsListBuilder,
 } from "@/sdks/replayCollection.js";
 export { ReplayEntrySDK, ReplayEntry } from "@/sdks/replayEntry.js";
+export { DNSRewriteSDK } from "@/sdks/dnsRewrite.js";

--- a/packages/sdk-client/src/types/dnsRewrite.ts
+++ b/packages/sdk-client/src/types/dnsRewrite.ts
@@ -1,0 +1,32 @@
+import type { ID } from "./index.js";
+
+/**
+ * DNS resolver - either IP-based or upstream resolver-based
+ */
+export type DNSResolver =
+  | { type: "ip"; ip: string }
+  | { type: "upstream"; id: ID };
+
+/**
+ * DNS rewrite information
+ */
+export type DNSRewrite = {
+  id: ID;
+  allowlist: string[];
+  denylist: string[];
+  enabled: boolean;
+  rank: number;
+  resolution: DNSResolver;
+};
+
+/**
+ * Options for creating a DNS rewrite
+ */
+export type CreateDNSRewriteOptions = {
+  /** The allowlist of glob patterns */
+  allowlist: string[];
+  /** The denylist of glob patterns */
+  denylist: string[];
+  /** The DNS resolver configuration */
+  resolution: DNSResolver;
+};

--- a/packages/sdk-client/src/types/index.ts
+++ b/packages/sdk-client/src/types/index.ts
@@ -14,6 +14,7 @@ export * from "./replayCollection.js";
 export * from "./network.js";
 export * from "./workflow.js";
 export * from "./instanceSettings.js";
+export * from "./dnsRewrite.js";
 
 /**
  * A unique Caido identifier per type.


### PR DESCRIPTION
## Spec
Implement `create()` method on a new `DNSRewriteSDK` class that wraps the `createDnsRewrite` GraphQL mutation. The method accepts `CreateDNSRewriteOptions`, maps input to the GraphQL mutation shape, processes the response via `mapToDnsRewrite()`, and handles errors via `handleGraphQLError()`. After instantiation, callers can invoke `client.dnsRewrite.create({ ... })` with full type safety.

## Key Changes

- **New SDK class**: `DNSRewriteSDK` with `create(options: CreateDNSRewriteOptions): Promise<DNSRewrite>` method
- **GraphQL mutation**: Added `createDnsRewrite` mutation document and generated TypeScript types
- **Type mapping**: Implemented `mapToDnsRewrite()` converter in `convert/dnsRewrite.ts` to transform GraphQL response to SDK-owned `DNSRewrite` type
- **Client integration**: Registered `dnsRewrite` property on Caido client for immediate access
- **Type exports**: Exported `CreateDNSRewriteOptions` and `DNSRewrite` types from `types/dnsRewrite.ts`

## Validation
- TypeScript compilation passes with no unused imports or exports
- GraphQL types generated cleanly from mutation document
- Error handling delegates to `handleGraphQLError()` for consistent payload validation

---

Closes caido/ai-ops#75