### PR TITLE
Add BackupSDK.list() to expose backups query

### DIFF
--- a/packages/sdk-client/src/client.ts
+++ b/packages/sdk-client/src/client.ts
@@ -5,6 +5,7 @@ import { ConsoleLogger } from "@/logger.js";
 import type { ClientOptions } from "@/options.js";
 import { RestClient } from "@/rest/index.js";
 import {
+  BackupSDK,
   EnvironmentSDK,
   FilterSDK,
   FindingSDK,
@@ -43,6 +44,7 @@ import { sleep } from "@/utils/misc.js";
  * - `instance` - Higher-level instance SDK
  * - `request` - Higher-level request SDK
  * - `workflow` - Higher-level workflow SDK
+ * - `backup` - Higher-level backup SDK
  *
  * @example
  * ```typescript
@@ -102,6 +104,9 @@ export class Client {
   /** Higher-level replay SDK. */
   readonly replay: ReplaySDK;
 
+  /** Higher-level backup SDK. */
+  readonly backup: BackupSDK;
+
   private readonly auth: AuthManager;
 
   constructor(options: ClientOptions) {
@@ -136,6 +141,7 @@ export class Client {
     this.workflow = new WorkflowSDK(this.graphql);
     this.task = new TaskSDK(this.graphql);
     this.replay = new ReplaySDK(this.graphql);
+    this.backup = new BackupSDK(this.graphql);
   }
 
   /**

--- a/packages/sdk-client/src/convert/backup.ts
+++ b/packages/sdk-client/src/convert/backup.ts
@@ -1,0 +1,11 @@
+import type { BackupFullFragment } from "@/graphql/index.js";
+import type { Backup } from "@/types/index.js";
+
+export const mapToBackup = (node: BackupFullFragment): Backup => {
+  return {
+    id: node.id,
+    name: node.name,
+    createdAt: new Date(node.createdAt),
+    status: node.status,
+  };
+};

--- a/packages/sdk-client/src/graphql/__generated__/backup.ts
+++ b/packages/sdk-client/src/graphql/__generated__/backup.ts
@@ -1,0 +1,88 @@
+import type * as Types from "./types.js";
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type BackupFullFragment = {
+  id: string;
+  name: string;
+  createdAt: string;
+  status: Types.BackupStatus;
+};
+
+export type BackupsQueryVariables = Types.Exact<{ [key: string]: never }>;
+
+export type BackupsQuery = {
+  backups: Array<{
+    id: string;
+    name: string;
+    createdAt: string;
+    status: Types.BackupStatus;
+  }>;
+};
+
+export const BackupFullFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "BackupFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Backup" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<BackupFullFragment, unknown>;
+export const BackupsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "Backups" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "backups" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "FragmentSpread",
+                  name: { kind: "Name", value: "BackupFull" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "BackupFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Backup" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<BackupsQuery, BackupsQueryVariables>;

--- a/packages/sdk-client/src/graphql/documents/backup.graphql
+++ b/packages/sdk-client/src/graphql/documents/backup.graphql
@@ -1,0 +1,12 @@
+fragment BackupFull on Backup {
+  id
+  name
+  createdAt
+  status
+}
+
+query Backups {
+  backups {
+    ...BackupFull
+  }
+}

--- a/packages/sdk-client/src/graphql/index.ts
+++ b/packages/sdk-client/src/graphql/index.ts
@@ -2,6 +2,7 @@ export * from "./client.js";
 export * from "./__generated__/viewer.js";
 export * from "./__generated__/types.js";
 export * from "./__generated__/enums.js";
+export * from "./__generated__/backup.js";
 export * from "./__generated__/environment.js";
 export * from "./__generated__/errors.js";
 export * from "./__generated__/filter.js";

--- a/packages/sdk-client/src/sdks/backup.ts
+++ b/packages/sdk-client/src/sdks/backup.ts
@@ -1,0 +1,22 @@
+import { mapToBackup } from "@/convert/backup.js";
+import { BackupsDocument, type GraphQLClient } from "@/graphql/index.js";
+import type { Backup } from "@/types/index.js";
+
+/**
+ * Higher-level SDK for backup-related operations.
+ */
+export class BackupSDK {
+  private readonly graphql: GraphQLClient;
+
+  constructor(graphql: GraphQLClient) {
+    this.graphql = graphql;
+  }
+
+  /**
+   * List all backups.
+   */
+  async list(): Promise<Backup[]> {
+    const result = await this.graphql.query(BackupsDocument);
+    return result.backups.map(mapToBackup);
+  }
+}

--- a/packages/sdk-client/src/sdks/index.ts
+++ b/packages/sdk-client/src/sdks/index.ts
@@ -1,3 +1,4 @@
+export { BackupSDK } from "@/sdks/backup.js";
 export { EnvironmentSDK, EnvironmentInstance } from "@/sdks/environment.js";
 export { FilterSDK } from "@/sdks/filter.js";
 export { HostedFileSDK } from "@/sdks/hostedFile.js";

--- a/packages/sdk-client/src/types/backup.ts
+++ b/packages/sdk-client/src/types/backup.ts
@@ -1,0 +1,13 @@
+import type { ID } from "./index.js";
+
+import type { BackupStatus } from "@/graphql/index.js";
+
+/**
+ * Backup information
+ */
+export type Backup = {
+  id: ID;
+  name: string;
+  createdAt: Date;
+  status: BackupStatus;
+};

--- a/packages/sdk-client/src/types/index.ts
+++ b/packages/sdk-client/src/types/index.ts
@@ -14,6 +14,7 @@ export * from "./replayCollection.js";
 export * from "./network.js";
 export * from "./workflow.js";
 export * from "./instanceSettings.js";
+export * from "./backup.js";
 
 /**
  * A unique Caido identifier per type.


### PR DESCRIPTION
## Spec
Adds `BackupSDK` class with a public `list()` method that exposes the `backups` Query field from the GraphQL schema. Consumers can call `await client.backup.list()` and receive an array of `Backup` objects containing id, name, createdAt, status, etc.

## Key Changes
- **BackupSDK class** (`sdks/backup.ts`): New SDK class with async `list()` method that queries GraphQL backups field and returns `Promise<Backup[]>`
- **Backup type definitions** (`types/backup.ts`): Type definitions for Backup objects with id, name, createdAt, status fields
- **GraphQL document** (`graphql/documents/backup.graphql`): New backups query document
- **Generated GraphQL types** (`graphql/__generated__/backup.ts`): Auto-generated TypeScript types from GraphQL schema
- **Backup converter** (`convert/backup.ts`): Conversion logic to transform GraphQL responses to Backup type
- **Client integration** (`client.ts`): Registers BackupSDK instance as `client.backup`
- **Exports** (`sdks/index.ts`, `types/index.ts`, `graphql/index.ts`): Public API exports for BackupSDK and Backup types

## Implementation Notes
- The `list()` method is async and returns a Promise to align with GraphQL query patterns
- Backup objects are converted from GraphQL response format to the public Backup type
- BackupSDK is exported as a public property on the SDK client for consumer access

Closes caido/ai-ops#78