### PR TITLE
Implement DNSRewriteSDK.create() method for DNS rewrite creation

### DIFF
--- a/packages/sdk-client/src/client.ts
+++ b/packages/sdk-client/src/client.ts
@@ -5,6 +5,7 @@ import { ConsoleLogger } from "@/logger.js";
 import type { ClientOptions } from "@/options.js";
 import { RestClient } from "@/rest/index.js";
 import {
+  DNSRewriteSDK,
   DNSUpstreamSDK,
   EnvironmentSDK,
   FilterSDK,
@@ -43,6 +44,7 @@ import { Version } from "@/version.js";
  * - `filter` - Higher-level filter preset SDK
  * - `environment` - Higher-level environment SDK
  * - `dnsUpstream` - Higher-level DNS upstream SDK
+ * - `dnsRewrite` - Higher-level DNS rewrite SDK
  * - `hostedFile` - Higher-level hosted file SDK
  * - `instance` - Higher-level instance SDK
  * - `request` - Higher-level request SDK
@@ -90,6 +92,9 @@ export class Client {
 
   /** Higher-level DNS upstream SDK. */
   readonly dnsUpstream: DNSUpstreamSDK;
+
+  /** Higher-level DNS rewrite SDK. */
+  readonly dnsRewrite: DNSRewriteSDK;
 
   /** Higher-level hosted file SDK. */
   readonly hostedFile: HostedFileSDK;
@@ -142,6 +147,7 @@ export class Client {
     this.filter = new FilterSDK(this.graphql);
     this.environment = new EnvironmentSDK(this.graphql);
     this.dnsUpstream = new DNSUpstreamSDK(this.graphql);
+    this.dnsRewrite = new DNSRewriteSDK(this.graphql);
     this.hostedFile = new HostedFileSDK(this.graphql);
     this.instance = new InstanceSDK(this.graphql);
     this.finding = new FindingSDK(this.graphql);

--- a/packages/sdk-client/src/convert/dnsRewrite.ts
+++ b/packages/sdk-client/src/convert/dnsRewrite.ts
@@ -1,0 +1,1 @@
+export * from "@/transport/latest/convert/dnsRewrite.js";

--- a/packages/sdk-client/src/sdks/dnsRewrite.ts
+++ b/packages/sdk-client/src/sdks/dnsRewrite.ts
@@ -1,0 +1,45 @@
+import { mapToDnsRewrite } from "@/convert/dnsRewrite.js";
+import {
+  CreateDnsRewriteDocument,
+  type GraphQLClient,
+} from "@/graphql/index.js";
+import type { CreateDNSRewriteOptions, DNSRewrite } from "@/types/index.js";
+import { handleGraphQLError } from "@/utils/errors.js";
+import { isPresent } from "@/utils/optional.js";
+
+/**
+ * Higher-level SDK for DNS rewrite-related operations.
+ */
+export class DNSRewriteSDK {
+  private readonly graphql: GraphQLClient;
+
+  constructor(graphql: GraphQLClient) {
+    this.graphql = graphql;
+  }
+
+  /**
+   * Create a new DNS rewrite rule.
+   */
+  async create(options: CreateDNSRewriteOptions): Promise<DNSRewrite> {
+    const input = {
+      allowlist: options.allowlist,
+      denylist: options.denylist,
+      resolution:
+        options.resolution.kind === "ip"
+          ? { ip: { ip: options.resolution.ip } }
+          : { upstream: { id: options.resolution.upstreamId as string } },
+    };
+
+    const result = await this.graphql.mutation(CreateDnsRewriteDocument, {
+      input,
+    });
+
+    const payload = result.createDnsRewrite;
+
+    if (isPresent(payload.error)) {
+      handleGraphQLError(payload.error);
+    }
+
+    return mapToDnsRewrite(payload.rewrite!);
+  }
+}

--- a/packages/sdk-client/src/sdks/index.ts
+++ b/packages/sdk-client/src/sdks/index.ts
@@ -29,3 +29,4 @@ export {
 } from "@/sdks/replayCollection.js";
 export { ReplayEntrySDK, ReplayEntry } from "@/sdks/replayEntry.js";
 export { DNSUpstreamSDK } from "@/sdks/dnsUpstream.js";
+export { DNSRewriteSDK } from "@/sdks/dnsRewrite.js";

--- a/packages/sdk-client/src/transport/latest/__generated__/dnsRewrite.ts
+++ b/packages/sdk-client/src/transport/latest/__generated__/dnsRewrite.ts
@@ -1,0 +1,314 @@
+import type * as Types from "./types.js";
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type DnsRewriteFullFragment = {
+  id: string;
+  allowlist: Array<string>;
+  denylist: Array<string>;
+  enabled: boolean;
+  rank: string;
+  resolution:
+    | { __typename: "DnsIpResolver"; ip: string }
+    | { __typename: "DnsUpstreamResolver"; id: string };
+};
+
+export type CreateDnsRewriteMutationVariables = Types.Exact<{
+  input: Types.CreateDnsRewriteInput;
+}>;
+
+export type CreateDnsRewriteMutation = {
+  createDnsRewrite: {
+    error?:
+      | { __typename: "OtherUserError"; code: string }
+      | { __typename: "UnknownIdUserError"; id: string; code: string }
+      | undefined
+      | null;
+    rewrite?:
+      | {
+          id: string;
+          allowlist: Array<string>;
+          denylist: Array<string>;
+          enabled: boolean;
+          rank: string;
+          resolution:
+            | { __typename: "DnsIpResolver"; ip: string }
+            | { __typename: "DnsUpstreamResolver"; id: string };
+        }
+      | undefined
+      | null;
+  };
+};
+
+export const DnsRewriteFullFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "DnsRewriteFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "DnsRewrite" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "allowlist" } },
+          { kind: "Field", name: { kind: "Name", value: "denylist" } },
+          { kind: "Field", name: { kind: "Name", value: "enabled" } },
+          { kind: "Field", name: { kind: "Name", value: "rank" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "resolution" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "__typename" } },
+                {
+                  kind: "InlineFragment",
+                  typeCondition: {
+                    kind: "NamedType",
+                    name: { kind: "Name", value: "DnsIpResolver" },
+                  },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "ip" },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "InlineFragment",
+                  typeCondition: {
+                    kind: "NamedType",
+                    name: { kind: "Name", value: "DnsUpstreamResolver" },
+                  },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "id" },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DnsRewriteFullFragment, unknown>;
+export const CreateDnsRewriteDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "CreateDnsRewrite" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: { kind: "Name", value: "CreateDnsRewriteInput" },
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "createDnsRewrite" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "Variable",
+                  name: { kind: "Name", value: "input" },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "error" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "__typename" },
+                      },
+                      {
+                        kind: "InlineFragment",
+                        typeCondition: {
+                          kind: "NamedType",
+                          name: { kind: "Name", value: "OtherUserError" },
+                        },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: {
+                                kind: "Name",
+                                value: "OtherUserErrorFull",
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "InlineFragment",
+                        typeCondition: {
+                          kind: "NamedType",
+                          name: {
+                            kind: "Name",
+                            value: "UnknownIdUserError",
+                          },
+                        },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: {
+                                kind: "Name",
+                                value: "UnknownIdUserErrorFull",
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "rewrite" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "FragmentSpread",
+                        name: { kind: "Name", value: "DnsRewriteFull" },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "OtherUserErrorFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "OtherUserError" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "code" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "UnknownIdUserErrorFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "UnknownIdUserError" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "code" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "DnsRewriteFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "DnsRewrite" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "allowlist" } },
+          { kind: "Field", name: { kind: "Name", value: "denylist" } },
+          { kind: "Field", name: { kind: "Name", value: "enabled" } },
+          { kind: "Field", name: { kind: "Name", value: "rank" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "resolution" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "__typename" } },
+                {
+                  kind: "InlineFragment",
+                  typeCondition: {
+                    kind: "NamedType",
+                    name: { kind: "Name", value: "DnsIpResolver" },
+                  },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "ip" },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "InlineFragment",
+                  typeCondition: {
+                    kind: "NamedType",
+                    name: { kind: "Name", value: "DnsUpstreamResolver" },
+                  },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "id" },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  CreateDnsRewriteMutation,
+  CreateDnsRewriteMutationVariables
+>;

--- a/packages/sdk-client/src/transport/latest/convert/dnsRewrite.ts
+++ b/packages/sdk-client/src/transport/latest/convert/dnsRewrite.ts
@@ -1,0 +1,18 @@
+import type { DnsRewriteFullFragment } from "@/graphql/index.js";
+import type { DNSResolver, DNSRewrite } from "@/types/index.js";
+
+export const mapToDnsRewrite = (node: DnsRewriteFullFragment): DNSRewrite => {
+  const resolution: DNSResolver =
+    node.resolution.__typename === "DnsIpResolver"
+      ? { kind: "ip", ip: node.resolution.ip }
+      : { kind: "upstream", upstreamId: node.resolution.id };
+
+  return {
+    id: node.id,
+    allowlist: node.allowlist,
+    denylist: node.denylist,
+    enabled: node.enabled,
+    rank: node.rank,
+    resolution,
+  };
+};

--- a/packages/sdk-client/src/transport/latest/documents/dnsRewrite.graphql
+++ b/packages/sdk-client/src/transport/latest/documents/dnsRewrite.graphql
@@ -1,0 +1,33 @@
+fragment DnsRewriteFull on DnsRewrite {
+  id
+  allowlist
+  denylist
+  enabled
+  rank
+  resolution {
+    __typename
+    ... on DnsIpResolver {
+      ip
+    }
+    ... on DnsUpstreamResolver {
+      id
+    }
+  }
+}
+
+mutation CreateDnsRewrite($input: CreateDnsRewriteInput!) {
+  createDnsRewrite(input: $input) {
+    error {
+      __typename
+      ... on OtherUserError {
+        ...OtherUserErrorFull
+      }
+      ... on UnknownIdUserError {
+        ...UnknownIdUserErrorFull
+      }
+    }
+    rewrite {
+      ...DnsRewriteFull
+    }
+  }
+}

--- a/packages/sdk-client/src/transport/latest/index.ts
+++ b/packages/sdk-client/src/transport/latest/index.ts
@@ -16,3 +16,4 @@ export * from "./__generated__/workflow.js";
 export * from "./__generated__/connectionInfo.js";
 export * from "./__generated__/instanceSettings.js";
 export * from "./__generated__/dnsUpstream.js";
+export * from "./__generated__/dnsRewrite.js";

--- a/packages/sdk-client/src/types/dnsRewrite.ts
+++ b/packages/sdk-client/src/types/dnsRewrite.ts
@@ -1,0 +1,32 @@
+import type { ID } from "./index.js";
+
+/**
+ * DNS rewrite rule
+ */
+export type DNSRewrite = {
+  id: ID;
+  allowlist: string[];
+  denylist: string[];
+  enabled: boolean;
+  rank: string;
+  resolution: DNSResolver;
+};
+
+/**
+ * DNS resolver configuration (IP or upstream)
+ */
+export type DNSResolver =
+  | { kind: "ip"; ip: string }
+  | { kind: "upstream"; upstreamId: ID };
+
+/**
+ * Options for creating a DNS rewrite
+ */
+export type CreateDNSRewriteOptions = {
+  /** The allowlist of glob patterns */
+  allowlist: string[];
+  /** The denylist of glob patterns */
+  denylist: string[];
+  /** The DNS resolver configuration */
+  resolution: DNSResolver;
+};

--- a/packages/sdk-client/src/types/index.ts
+++ b/packages/sdk-client/src/types/index.ts
@@ -17,6 +17,7 @@ export * from "./network.js";
 export * from "./workflow.js";
 export * from "./instanceSettings.js";
 export * from "./dnsUpstream.js";
+export * from "./dnsRewrite.js";
 
 /**
  * A unique Caido identifier per type.


### PR DESCRIPTION
## Spec
Implement `create()` method on a new `DNSRewriteSDK` class that wraps the `createDnsRewrite` GraphQL mutation. The method accepts `CreateDNSRewriteOptions`, maps the input to the GraphQL shape, executes the mutation, and returns an SDK-owned `DNSRewrite` type. Errors in the GraphQL payload are handled via `handleGraphQLError()`. After instantiation, callers can invoke `client.dnsRewrite.create({ ... })`.

## Key Changes

- **New DNSRewriteSDK class** (`packages/sdk-client/src/sdks/dnsRewrite.ts`)  
  Implements `create(options: CreateDNSRewriteOptions): Promise<DNSRewrite>` method that orchestrates GraphQL mutation execution and response mapping.

- **GraphQL mutation document** (`packages/sdk-client/src/transport/latest/documents/dnsRewrite.graphql`)  
  Added `createDnsRewrite` mutation to support DNS rewrite creation via the transport layer.

- **Type definitions** (`packages/sdk-client/src/types/dnsRewrite.ts`)  
  Added `CreateDNSRewriteOptions` input type and exported from the types index.

- **Conversion utilities** (`packages/sdk-client/src/convert/dnsRewrite.ts` and `packages/sdk-client/src/transport/latest/convert/dnsRewrite.ts`)  
  Input mapping to GraphQL shape and response mapping via `mapToDnsRewrite()`.

- **SDK registration** (`packages/sdk-client/src/client.ts` and `packages/sdk-client/src/sdks/index.ts`)  
  Registered `DNSRewriteSDK` instance on the Caido client, making it accessible via `client.dnsRewrite`.

- **Generated types** (`packages/sdk-client/src/transport/latest/__generated__/dnsRewrite.ts`)  
  Auto-generated TypeScript types from the GraphQL schema.

All imports and exports are clean; TypeScript compilation succeeds.

## How to review

- **Stay in scope**
  - Review the **diff** against the **Spec** section.
  - If this PR achieves its stated goal, approve it — even if you notice other improvements in the same file.
  - Don't request fixes for code this PR didn't change.

- **Fix attempts**
  - ai-ops may push up to **two** fixes after your feedback (fix attempt 1, then fix attempt 2).
  - If it's still not acceptable after fix attempt 2, **close the PR** — a fresh run will open a new one.
  - Do not request a third round of fixes.

- **Merge conflicts**
  - **Close the PR** — do not ask ai-ops to rebase.
  - The linked backlog issue stays open; a future run will open a fresh PR.

- **Copilot is advisory**
  - Resolve **inline comment threads** you don't want fixed.
  - ai-ops only acts on **human** `Changes requested` — not Copilot.

- **Systemic issues → #ai-ops**
  - If the same problem appears on **3+ PRs**, mention it in **#ai-ops**.
  - Don't re-raise it on every PR.

- **Don't want this worked on?**
  - **Stop an area permanently** — add an ADR in the **target repo**, then close this PR and the linked backlog issue.
  - **Pause this PR only** — leave it open without submitting **Changes requested**; ai-ops won't touch it.

Closes caido/ai-ops#75