### PR TITLE
Add BackupSDK.list() to expose backups query

### DIFF
--- a/packages/sdk-client/src/client.ts
+++ b/packages/sdk-client/src/client.ts
@@ -5,6 +5,7 @@ import { ConsoleLogger } from "@/logger.js";
 import type { ClientOptions } from "@/options.js";
 import { RestClient } from "@/rest/index.js";
 import {
+  BackupSDK,
   DNSUpstreamSDK,
   EnvironmentSDK,
   FilterSDK,
@@ -44,6 +45,7 @@ import { Version } from "@/version.js";
  * - `environment` - Higher-level environment SDK
  * - `dnsUpstream` - Higher-level DNS upstream SDK
  * - `hostedFile` - Higher-level hosted file SDK
+ * - `backup` - Higher-level backup SDK
  * - `instance` - Higher-level instance SDK
  * - `request` - Higher-level request SDK
  * - `workflow` - Higher-level workflow SDK
@@ -94,6 +96,9 @@ export class Client {
   /** Higher-level hosted file SDK. */
   readonly hostedFile: HostedFileSDK;
 
+  /** Higher-level backup SDK. */
+  readonly backup: BackupSDK;
+
   /** Higher-level instance SDK. */
   readonly instance: InstanceSDK;
 
@@ -143,6 +148,7 @@ export class Client {
     this.environment = new EnvironmentSDK(this.graphql);
     this.dnsUpstream = new DNSUpstreamSDK(this.graphql);
     this.hostedFile = new HostedFileSDK(this.graphql);
+    this.backup = new BackupSDK(this.graphql);
     this.instance = new InstanceSDK(this.graphql);
     this.finding = new FindingSDK(this.graphql);
     this.request = new RequestSDK(this.graphql);

--- a/packages/sdk-client/src/convert/backup.ts
+++ b/packages/sdk-client/src/convert/backup.ts
@@ -1,0 +1,1 @@
+export * from "@/transport/latest/convert/backup.js";

--- a/packages/sdk-client/src/sdks/backup.ts
+++ b/packages/sdk-client/src/sdks/backup.ts
@@ -1,0 +1,22 @@
+import { mapToBackup } from "@/convert/backup.js";
+import { BackupsDocument, type GraphQLClient } from "@/graphql/index.js";
+import type { Backup } from "@/types/index.js";
+
+/**
+ * Higher-level SDK for backup-related operations.
+ */
+export class BackupSDK {
+  private readonly graphql: GraphQLClient;
+
+  constructor(graphql: GraphQLClient) {
+    this.graphql = graphql;
+  }
+
+  /**
+   * List all backups.
+   */
+  async list(): Promise<Backup[]> {
+    const result = await this.graphql.query(BackupsDocument);
+    return result.backups.map(mapToBackup);
+  }
+}

--- a/packages/sdk-client/src/sdks/index.ts
+++ b/packages/sdk-client/src/sdks/index.ts
@@ -1,3 +1,4 @@
+export { BackupSDK } from "@/sdks/backup.js";
 export { EnvironmentSDK, EnvironmentInstance } from "@/sdks/environment.js";
 export { FilterSDK } from "@/sdks/filter.js";
 export { HostedFileSDK } from "@/sdks/hostedFile.js";

--- a/packages/sdk-client/src/transport/latest/__generated__/backup.ts
+++ b/packages/sdk-client/src/transport/latest/__generated__/backup.ts
@@ -1,0 +1,102 @@
+import type * as Types from "./types.js";
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+
+export type BackupFullFragment = {
+  id: string;
+  name: string;
+  path: string;
+  size: number;
+  status: Types.BackupStatus;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type BackupsQueryVariables = Types.Exact<{ [key: string]: never }>;
+
+export type BackupsQuery = {
+  backups: Array<{
+    id: string;
+    name: string;
+    path: string;
+    size: number;
+    status: Types.BackupStatus;
+    createdAt: string;
+    updatedAt: string;
+  }>;
+};
+
+export const BackupFullFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "BackupFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Backup" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "path" } },
+          { kind: "Field", name: { kind: "Name", value: "size" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<BackupFullFragment, unknown>;
+
+export const BackupsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "Backups" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "backups" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "FragmentSpread",
+                  name: { kind: "Name", value: "BackupFull" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "BackupFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Backup" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "path" } },
+          { kind: "Field", name: { kind: "Name", value: "size" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<BackupsQuery, BackupsQueryVariables>;

--- a/packages/sdk-client/src/transport/latest/convert/backup.ts
+++ b/packages/sdk-client/src/transport/latest/convert/backup.ts
@@ -1,0 +1,14 @@
+import type { BackupFullFragment } from "@/graphql/index.js";
+import type { Backup } from "@/types/index.js";
+
+export const mapToBackup = (node: BackupFullFragment): Backup => {
+  return {
+    id: node.id,
+    name: node.name,
+    path: node.path,
+    size: node.size,
+    status: node.status,
+    createdAt: new Date(node.createdAt),
+    updatedAt: new Date(node.updatedAt),
+  };
+};

--- a/packages/sdk-client/src/transport/latest/documents/backup.graphql
+++ b/packages/sdk-client/src/transport/latest/documents/backup.graphql
@@ -1,0 +1,15 @@
+fragment BackupFull on Backup {
+  id
+  name
+  path
+  size
+  status
+  createdAt
+  updatedAt
+}
+
+query Backups {
+  backups {
+    ...BackupFull
+  }
+}

--- a/packages/sdk-client/src/transport/latest/index.ts
+++ b/packages/sdk-client/src/transport/latest/index.ts
@@ -1,6 +1,7 @@
 export * from "./__generated__/viewer.js";
 export * from "./__generated__/types.js";
 export * from "./__generated__/enums.js";
+export * from "./__generated__/backup.js";
 export * from "./__generated__/environment.js";
 export * from "./__generated__/errors.js";
 export * from "./__generated__/filter.js";

--- a/packages/sdk-client/src/types/backup.ts
+++ b/packages/sdk-client/src/types/backup.ts
@@ -1,0 +1,16 @@
+import type { ID } from "./index.js";
+
+import type { BackupStatus } from "@/graphql/index.js";
+
+/**
+ * Backup information
+ */
+export type Backup = {
+  id: ID;
+  name: string;
+  path: string;
+  size: number;
+  status: BackupStatus;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/packages/sdk-client/src/types/index.ts
+++ b/packages/sdk-client/src/types/index.ts
@@ -17,6 +17,7 @@ export * from "./network.js";
 export * from "./workflow.js";
 export * from "./instanceSettings.js";
 export * from "./dnsUpstream.js";
+export * from "./backup.js";
 
 /**
  * A unique Caido identifier per type.


### PR DESCRIPTION
## Spec
This implements the `backup-sdk-list` feature: adds a `BackupSDK` class with a public async `list()` method that queries the backups Query field from the GraphQL schema. The method returns `Promise<Backup[]>`, allowing consumers to call `await client.backup.list()` and receive backup objects with id, name, createdAt, status, etc.

## Key Changes
- **BackupSDK class** (`packages/sdk-client/src/sdks/backup.ts`): New SDK class with async `list()` method that executes the backups query
- **Type definitions** (`packages/sdk-client/src/types/backup.ts`): Backup type with id, name, createdAt, status fields
- **GraphQL document** (`packages/sdk-client/src/transport/latest/documents/backup.graphql`): backups query definition
- **Generated types** (`packages/sdk-client/src/transport/latest/__generated__/backup.ts`): Auto-generated GraphQL types and operations
- **Conversion layer** (`packages/sdk-client/src/convert/backup.ts`, `packages/sdk-client/src/transport/latest/convert/backup.ts`): Maps raw GraphQL responses to Backup domain types
- **Client integration** (`packages/sdk-client/src/client.ts`): Registers BackupSDK instance on the client; exported from SDK index (`packages/sdk-client/src/sdks/index.ts`, `packages/sdk-client/src/types/index.ts`)

## Validation
BackupSDK.list() has been tested to execute successfully and return the expected Backup array structure.

## How to review

- **Stay in scope**
  - Review the **diff** against the **Spec** section.
  - If this PR achieves its stated goal, approve it — even if you notice other improvements in the same file.
  - Don't request fixes for code this PR didn't change.

- **Fix attempts**
  - ai-ops may push up to **two** fixes after your feedback (fix attempt 1, then fix attempt 2).
  - If it's still not acceptable after fix attempt 2, **close the PR** — a fresh run will open a new one.
  - Do not request a third round of fixes.

- **Merge conflicts**
  - **Close the PR** — do not ask ai-ops to rebase.
  - The linked backlog issue stays open; a future run will open a fresh PR.

- **Copilot is advisory**
  - Resolve **inline comment threads** you don't want fixed.
  - ai-ops only acts on **human** `Changes requested` — not Copilot.

- **Systemic issues → #ai-ops**
  - If the same problem appears on **3+ PRs**, mention it in **#ai-ops**.
  - Don't re-raise it on every PR.

- **Don't want this worked on?**
  - **Stop an area permanently** — add an ADR in the **target repo**, then close this PR and the linked backlog issue.
  - **Pause this PR only** — leave it open without submitting **Changes requested**; ai-ops won't touch it.

Closes caido/ai-ops#78