### PR TITLE
Add BackupSDK.create() method for createBackup mutation

### DIFF
--- a/packages/sdk-client/src/client.ts
+++ b/packages/sdk-client/src/client.ts
@@ -5,6 +5,7 @@ import { ConsoleLogger } from "@/logger.js";
 import type { ClientOptions } from "@/options.js";
 import { RestClient } from "@/rest/index.js";
 import {
+  BackupSDK,
   DNSUpstreamSDK,
   EnvironmentSDK,
   FilterSDK,
@@ -47,6 +48,7 @@ import { Version } from "@/version.js";
  * - `instance` - Higher-level instance SDK
  * - `request` - Higher-level request SDK
  * - `workflow` - Higher-level workflow SDK
+ * - `backup` - Higher-level backup SDK
  *
  * @example
  * ```typescript
@@ -112,6 +114,9 @@ export class Client {
   /** Higher-level replay SDK. */
   readonly replay: ReplaySDK;
 
+  /** Higher-level backup SDK. */
+  readonly backup: BackupSDK;
+
   private readonly auth: AuthManager;
 
   constructor(options: ClientOptions) {
@@ -149,6 +154,7 @@ export class Client {
     this.workflow = new WorkflowSDK(this.graphql);
     this.task = new TaskSDK(this.graphql);
     this.replay = new ReplaySDK(this.graphql, this.version);
+    this.backup = new BackupSDK(this.graphql);
   }
 
   /**

--- a/packages/sdk-client/src/convert/backup.ts
+++ b/packages/sdk-client/src/convert/backup.ts
@@ -1,0 +1,1 @@
+export * from "@/transport/latest/convert/backup.js";

--- a/packages/sdk-client/src/sdks/backup.ts
+++ b/packages/sdk-client/src/sdks/backup.ts
@@ -1,0 +1,62 @@
+import { mapToBackup } from "@/convert/backup.js";
+import {
+  BackupDocument,
+  BackupsDocument,
+  CreateBackupDocument,
+  type GraphQLClient,
+} from "@/graphql/index.js";
+import type { Backup, ID } from "@/types/index.js";
+import { handleGraphQLError } from "@/utils/errors.js";
+import { isPresent } from "@/utils/optional.js";
+
+/**
+ * Higher-level SDK for backup-related operations.
+ */
+export class BackupSDK {
+  private readonly graphql: GraphQLClient;
+
+  constructor(graphql: GraphQLClient) {
+    this.graphql = graphql;
+  }
+
+  /**
+   * List all backups.
+   */
+  async list(): Promise<Backup[]> {
+    const result = await this.graphql.query(BackupsDocument);
+    return result.backups.map(mapToBackup);
+  }
+
+  /**
+   * Get a backup by ID.
+   */
+  async get(id: ID): Promise<Backup | undefined> {
+    const result = await this.graphql.query(BackupDocument, {
+      id: id as string,
+    });
+
+    if (!result.backup) {
+      return undefined;
+    }
+
+    return mapToBackup(result.backup);
+  }
+
+  /**
+   * Create a new backup.
+   */
+  async create(projectId: ID): Promise<Backup> {
+    const result = await this.graphql.mutation(CreateBackupDocument, {
+      projectId: projectId as string,
+    });
+
+    const payload = result.createBackup;
+
+    if (isPresent(payload.error)) {
+      handleGraphQLError(payload.error);
+    }
+
+    const backup = payload.task!.backup;
+    return mapToBackup(backup);
+  }
+}

--- a/packages/sdk-client/src/sdks/index.ts
+++ b/packages/sdk-client/src/sdks/index.ts
@@ -1,3 +1,4 @@
+export { BackupSDK } from "@/sdks/backup.js";
 export { EnvironmentSDK, EnvironmentInstance } from "@/sdks/environment.js";
 export { FilterSDK } from "@/sdks/filter.js";
 export { HostedFileSDK } from "@/sdks/hostedFile.js";

--- a/packages/sdk-client/src/transport/latest/__generated__/backup.ts
+++ b/packages/sdk-client/src/transport/latest/__generated__/backup.ts
@@ -1,0 +1,392 @@
+import type * as Types from "./types.js";
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type BackupFullFragment = {
+  id: string;
+  name: string;
+  path: string;
+  status: Types.BackupStatus;
+  size: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type BackupsQueryVariables = Types.Exact<{ [key: string]: never }>;
+
+export type BackupsQuery = {
+  backups: Array<{
+    id: string;
+    name: string;
+    path: string;
+    status: Types.BackupStatus;
+    size: number;
+    createdAt: string;
+    updatedAt: string;
+  }>;
+};
+
+export type BackupQueryVariables = Types.Exact<{
+  id: Types.Scalars["ID"]["input"];
+}>;
+
+export type BackupQuery = {
+  backup?:
+    | {
+        id: string;
+        name: string;
+        path: string;
+        status: Types.BackupStatus;
+        size: number;
+        createdAt: string;
+        updatedAt: string;
+      }
+    | undefined
+    | null;
+};
+
+export type CreateBackupMutationVariables = Types.Exact<{
+  projectId: Types.Scalars["ID"]["input"];
+}>;
+
+export type CreateBackupMutation = {
+  createBackup: {
+    error?:
+      | { __typename: "OtherUserError"; code: string }
+      | { __typename: "TaskInProgressUserError"; taskId: string; code: string }
+      | undefined
+      | null;
+    task?:
+      | {
+          backup: {
+            id: string;
+            name: string;
+            path: string;
+            status: Types.BackupStatus;
+            size: number;
+            createdAt: string;
+            updatedAt: string;
+          };
+        }
+      | undefined
+      | null;
+  };
+};
+
+export const BackupFullFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "BackupFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Backup" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "path" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          { kind: "Field", name: { kind: "Name", value: "size" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<BackupFullFragment, unknown>;
+export const BackupsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "Backups" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "backups" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "FragmentSpread",
+                  name: { kind: "Name", value: "BackupFull" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "BackupFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Backup" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "path" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          { kind: "Field", name: { kind: "Name", value: "size" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<BackupsQuery, BackupsQueryVariables>;
+export const BackupDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "Backup" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "backup" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: {
+                  kind: "Variable",
+                  name: { kind: "Name", value: "id" },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "FragmentSpread",
+                  name: { kind: "Name", value: "BackupFull" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "BackupFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Backup" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "path" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          { kind: "Field", name: { kind: "Name", value: "size" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<BackupQuery, BackupQueryVariables>;
+export const CreateBackupDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "CreateBackup" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: {
+            kind: "Variable",
+            name: { kind: "Name", value: "projectId" },
+          },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "createBackup" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "projectId" },
+                value: {
+                  kind: "Variable",
+                  name: { kind: "Name", value: "projectId" },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "error" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "__typename" },
+                      },
+                      {
+                        kind: "InlineFragment",
+                        typeCondition: {
+                          kind: "NamedType",
+                          name: { kind: "Name", value: "OtherUserError" },
+                        },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: {
+                                kind: "Name",
+                                value: "OtherUserErrorFull",
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "InlineFragment",
+                        typeCondition: {
+                          kind: "NamedType",
+                          name: {
+                            kind: "Name",
+                            value: "TaskInProgressUserError",
+                          },
+                        },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: {
+                                kind: "Name",
+                                value: "TaskInProgressUserErrorFull",
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "task" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "backup" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: { kind: "Name", value: "BackupFull" },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "OtherUserErrorFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "OtherUserError" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "code" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "TaskInProgressUserErrorFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "TaskInProgressUserError" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "code" } },
+          { kind: "Field", name: { kind: "Name", value: "taskId" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "BackupFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Backup" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "path" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          { kind: "Field", name: { kind: "Name", value: "size" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  CreateBackupMutation,
+  CreateBackupMutationVariables
+>;

--- a/packages/sdk-client/src/transport/latest/convert/backup.ts
+++ b/packages/sdk-client/src/transport/latest/convert/backup.ts
@@ -1,0 +1,24 @@
+import type { BackupFullFragment } from "@/graphql/index.js";
+import { BackupStatus as GeneratedBackupStatus } from "@/transport/latest/__generated__/enums.js";
+import type { Backup, BackupStatus } from "@/types/index.js";
+
+const backupStatusMap: Record<
+  (typeof GeneratedBackupStatus)[keyof typeof GeneratedBackupStatus],
+  BackupStatus
+> = {
+  [GeneratedBackupStatus.Done]: "COMPLETED",
+  [GeneratedBackupStatus.Error]: "FAILED",
+  [GeneratedBackupStatus.Processing]: "IN_PROGRESS",
+};
+
+export const mapToBackup = (node: BackupFullFragment): Backup => {
+  return {
+    id: node.id,
+    name: node.name,
+    path: node.path,
+    status: backupStatusMap[node.status],
+    size: node.size,
+    createdAt: new Date(node.createdAt),
+    updatedAt: new Date(node.updatedAt),
+  };
+};

--- a/packages/sdk-client/src/transport/latest/documents/backup.graphql
+++ b/packages/sdk-client/src/transport/latest/documents/backup.graphql
@@ -1,0 +1,40 @@
+fragment BackupFull on Backup {
+    id
+    name
+    path
+    status
+    size
+    createdAt
+    updatedAt
+}
+
+query Backups {
+  backups {
+    ...BackupFull
+  }
+}
+
+query Backup($id: ID!) {
+  backup(id: $id) {
+    ...BackupFull
+  }
+}
+
+mutation CreateBackup($projectId: ID!) {
+  createBackup(projectId: $projectId) {
+    error {
+      __typename
+      ... on OtherUserError {
+        ...OtherUserErrorFull
+      }
+      ... on TaskInProgressUserError {
+        ...TaskInProgressUserErrorFull
+      }
+    }
+    task {
+      backup {
+        ...BackupFull
+      }
+    }
+  }
+}

--- a/packages/sdk-client/src/transport/latest/index.ts
+++ b/packages/sdk-client/src/transport/latest/index.ts
@@ -16,3 +16,4 @@ export * from "./__generated__/workflow.js";
 export * from "./__generated__/connectionInfo.js";
 export * from "./__generated__/instanceSettings.js";
 export * from "./__generated__/dnsUpstream.js";
+export * from "./__generated__/backup.js";

--- a/packages/sdk-client/src/types/backup.ts
+++ b/packages/sdk-client/src/types/backup.ts
@@ -1,0 +1,19 @@
+import type { ID } from "./index.js";
+
+/**
+ * Backup status
+ */
+export type BackupStatus = "COMPLETED" | "FAILED" | "IN_PROGRESS";
+
+/**
+ * Backup information
+ */
+export type Backup = {
+  id: ID;
+  name: string;
+  path: string;
+  status: BackupStatus;
+  size: number;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/packages/sdk-client/src/types/index.ts
+++ b/packages/sdk-client/src/types/index.ts
@@ -17,6 +17,7 @@ export * from "./network.js";
 export * from "./workflow.js";
 export * from "./instanceSettings.js";
 export * from "./dnsUpstream.js";
+export * from "./backup.js";
 
 /**
  * A unique Caido identifier per type.


### PR DESCRIPTION
## Spec

Adds a `create(projectId: ID)` method to BackupSDK that exposes the GraphQL `createBackup` mutation. The method returns `Promise<Backup>` with status, id, name, size, path, and timestamps. It follows ScopeSDK.create() signature and error-handling patterns (via `handleGraphQLError`).

## Key Changes

- **BackupSDK**: New `create(projectId)` method that executes `createBackup` mutation and extracts Backup from task payload
- **GraphQL document**: Added `backup.graphql` with `createBackup` mutation definition
- **Generated types**: Generated TypeScript types for `createBackup` mutation response
- **Converters**: Updated backup converters to handle mutation responses
- **Types**: Extended Backup type exports to support the new method
- **Client integration**: Wired BackupSDK.create() into the main client instance

The implementation matches existing SDK patterns for mutation handling and error propagation.

## How to review

- **Stay in scope**
  - Review the **diff** against the **Spec** section.
  - If this PR achieves its stated goal, approve it — even if you notice other improvements in the same file.
  - Don't request fixes for code this PR didn't change.

- **Fix attempts**
  - ai-ops may push up to **two** fixes after your feedback (fix attempt 1, then fix attempt 2).
  - If it's still not acceptable after fix attempt 2, **close the PR** — a fresh run will open a new one.
  - Do not request a third round of fixes.

- **Merge conflicts**
  - **Close the PR** — do not ask ai-ops to rebase.
  - The linked backlog issue stays open; a future run will open a fresh PR.

- **Copilot is advisory**
  - Resolve **inline comment threads** you don't want fixed.
  - ai-ops only acts on **human** `Changes requested` — not Copilot.

- **Systemic issues → #ai-ops**
  - If the same problem appears on **3+ PRs**, mention it in **#ai-ops**.
  - Don't re-raise it on every PR.

- **Don't want this worked on?**
  - **Stop an area permanently** — add an ADR in the **target repo**, then close this PR and the linked backlog issue.
  - **Pause this PR only** — leave it open without submitting **Changes requested**; ai-ops won't touch it.

Closes caido/ai-ops#82