### PR TITLE
Implement BackupSDK.delete() method for deleteBackup mutation

### DIFF
--- a/packages/sdk-client/src/client.ts
+++ b/packages/sdk-client/src/client.ts
@@ -5,6 +5,7 @@ import { ConsoleLogger } from "@/logger.js";
 import type { ClientOptions } from "@/options.js";
 import { RestClient } from "@/rest/index.js";
 import {
+  BackupSDK,
   DNSUpstreamSDK,
   EnvironmentSDK,
   FilterSDK,
@@ -37,6 +38,7 @@ import { Version } from "@/version.js";
  * - `rest` - Low-level REST client (GET, POST)
  * - `version` - Instance version handle (lazy `/health` or seeded)
  * - `user` - Higher-level user SDK
+ * - `backup` - Higher-level backup SDK
  * - `plugin` - Higher-level plugin SDK
  * - `project` - Higher-level project SDK
  * - `scope` - Higher-level scope SDK
@@ -72,6 +74,9 @@ export class Client {
 
   /** Higher-level user SDK. */
   readonly user: UserSDK;
+
+  /** Higher-level backup SDK. */
+  readonly backup: BackupSDK;
 
   /** Higher-level plugin SDK. */
   readonly plugin: PluginSDK;
@@ -136,6 +141,7 @@ export class Client {
     this.version = options.version ?? Version.lazy(this.rest);
 
     this.user = new UserSDK(this.graphql);
+    this.backup = new BackupSDK(this.graphql);
     this.plugin = new PluginSDK(this.graphql, this.rest);
     this.project = new ProjectSDK(this.graphql);
     this.scope = new ScopeSDK(this.graphql);

--- a/packages/sdk-client/src/sdks/backup.ts
+++ b/packages/sdk-client/src/sdks/backup.ts
@@ -1,0 +1,37 @@
+import {
+  DeleteBackupDocument,
+  type DeleteBackupMutation,
+  type GraphQLClient,
+} from "@/graphql/index.js";
+import type { ID } from "@/types/index.js";
+import { handleGraphQLError } from "@/utils/errors.js";
+import { isPresent } from "@/utils/optional.js";
+
+/**
+ * Higher-level SDK for backup-related operations.
+ */
+export class BackupSDK {
+  private readonly graphql: GraphQLClient;
+
+  constructor(graphql: GraphQLClient) {
+    this.graphql = graphql;
+  }
+
+  /**
+   * Delete a backup by ID.
+   */
+  async delete(id: ID): Promise<void> {
+    const result: DeleteBackupMutation = await this.graphql.mutation(
+      DeleteBackupDocument,
+      {
+        id: id as string,
+      },
+    );
+
+    const payload = result.deleteBackup;
+
+    if (isPresent(payload.error)) {
+      handleGraphQLError(payload.error);
+    }
+  }
+}

--- a/packages/sdk-client/src/sdks/index.ts
+++ b/packages/sdk-client/src/sdks/index.ts
@@ -1,3 +1,4 @@
+export { BackupSDK } from "@/sdks/backup.js";
 export { EnvironmentSDK, EnvironmentInstance } from "@/sdks/environment.js";
 export { FilterSDK } from "@/sdks/filter.js";
 export { HostedFileSDK } from "@/sdks/hostedFile.js";

--- a/packages/sdk-client/src/transport/latest/__generated__/backup.ts
+++ b/packages/sdk-client/src/transport/latest/__generated__/backup.ts
@@ -1,0 +1,144 @@
+import type * as Types from "./types.js";
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type DeleteBackupMutationVariables = Types.Exact<{
+  id: Types.Scalars["ID"]["input"];
+}>;
+
+export type DeleteBackupMutation = {
+  deleteBackup: {
+    deletedId?: string | undefined | null;
+    error?:
+      | { __typename: "OtherUserError"; code: string }
+      | { __typename: "TaskInProgressUserError"; taskId: string; code: string }
+      | undefined
+      | null;
+  };
+};
+
+export const DeleteBackupDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "DeleteBackup" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "deleteBackup" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: {
+                  kind: "Variable",
+                  name: { kind: "Name", value: "id" },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "deletedId" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "error" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "InlineFragment",
+                        typeCondition: {
+                          kind: "NamedType",
+                          name: { kind: "Name", value: "OtherUserError" },
+                        },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: {
+                                kind: "Name",
+                                value: "OtherUserErrorFull",
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "InlineFragment",
+                        typeCondition: {
+                          kind: "NamedType",
+                          name: {
+                            kind: "Name",
+                            value: "TaskInProgressUserError",
+                          },
+                        },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: {
+                                kind: "Name",
+                                value: "TaskInProgressUserErrorFull",
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "OtherUserErrorFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "OtherUserError" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "code" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "TaskInProgressUserErrorFull" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "TaskInProgressUserError" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "taskId" } },
+          { kind: "Field", name: { kind: "Name", value: "code" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DeleteBackupMutation, DeleteBackupMutationVariables>;

--- a/packages/sdk-client/src/transport/latest/documents/backup.graphql
+++ b/packages/sdk-client/src/transport/latest/documents/backup.graphql
@@ -1,0 +1,14 @@
+mutation DeleteBackup($id: ID!) {
+  deleteBackup(id: $id) {
+    deletedId
+    error {
+      __typename
+      ... on OtherUserError {
+        ...OtherUserErrorFull
+      }
+      ... on TaskInProgressUserError {
+        ...TaskInProgressUserErrorFull
+      }
+    }
+  }
+}

--- a/packages/sdk-client/src/transport/latest/index.ts
+++ b/packages/sdk-client/src/transport/latest/index.ts
@@ -1,6 +1,7 @@
 export * from "./__generated__/viewer.js";
 export * from "./__generated__/types.js";
 export * from "./__generated__/enums.js";
+export * from "./__generated__/backup.js";
 export * from "./__generated__/environment.js";
 export * from "./__generated__/errors.js";
 export * from "./__generated__/filter.js";


### PR DESCRIPTION
## Spec
Implement `BackupSDK.delete(id: ID): Promise<void>` to expose the deleteBackup GraphQL mutation. Callers can delete backups via `client.backup.delete(backupId)`.

## Key Changes
- **backup.ts** — Added `delete(id)` method to BackupSDK class that invokes the deleteBackup mutation and returns `Promise<void>`
- **backup.graphql** — Defined `deleteBackup` mutation document with ID parameter
- **backup.ts (generated)** — GraphQL codegen output includes `DeleteBackupDocument` and typed operation
- **client.ts** — BackupSDK instance wired into Client, accessible as public API surface
- **transport/latest/index.ts** — Exported generated types

The implementation follows existing SDK patterns and integrates with the GraphQL code generation pipeline. No breaking changes.

## How to review

- **Stay in scope**
  - Review the **diff** against the **Spec** section.
  - If this PR achieves its stated goal, approve it — even if you notice other improvements in the same file.
  - Don't request fixes for code this PR didn't change.

- **Fix attempts**
  - ai-ops may push up to **two** fixes after your feedback (fix attempt 1, then fix attempt 2).
  - If it's still not acceptable after fix attempt 2, **close the PR** — a fresh run will open a new one.
  - Do not request a third round of fixes.

- **Merge conflicts**
  - **Close the PR** — do not ask ai-ops to rebase.
  - The linked backlog issue stays open; a future run will open a fresh PR.

- **Copilot is advisory**
  - Resolve **inline comment threads** you don't want fixed.
  - ai-ops only acts on **human** `Changes requested` — not Copilot.

- **Systemic issues → #ai-ops**
  - If the same problem appears on **3+ PRs**, mention it in **#ai-ops**.
  - Don't re-raise it on every PR.

- **Don't want this worked on?**
  - **Stop an area permanently** — add an ADR in the **target repo**, then close this PR and the linked backlog issue.
  - **Pause this PR only** — leave it open without submitting **Changes requested**; ai-ops won't touch it.

Closes caido/ai-ops#144